### PR TITLE
Fix for Maximum call stack size exceeded error

### DIFF
--- a/src/depgraph.ts
+++ b/src/depgraph.ts
@@ -141,7 +141,9 @@ export class MavenDependencyGraph {
           if (!dependencyPkg) {
             throw new Error(`Failed to find a dependency package for '${dependencyId}'`);
           }
-          pkg.dependsOn(dependencyPkg);
+          if (pkg.packageURL.namespace != dependencyPkg.packageURL.namespace || pkg.packageURL.name != dependencyPkg.packageURL.name ) {
+            pkg.dependsOn(dependencyPkg);
+          }
         });
       }
     });

--- a/src/snapshot-generator.test.ts
+++ b/src/snapshot-generator.test.ts
@@ -10,7 +10,7 @@ describe('snapshot-generator', () => {
     it('should generate a snapshot for a simple project', async () => {
       const projectDir = getMavenProjectDirectory('simple');
       const depGraph = await generateDependencyGraph(projectDir);
-      expect(depGraph.dependencies.length).toBe(20);
+      expect(depGraph.dependencies.length).toBe(27);
     });
   });
 

--- a/test-data/maven/simple/pom.xml
+++ b/test-data/maven/simple/pom.xml
@@ -81,6 +81,13 @@
             <version>4.13</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- dependency triggering Maximum call stack size exceeded -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>2.0.54.Final</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Referencing https://github.com/advanced-security/maven-dependency-submission-action/issues/13

A "Maximum call stack size exceeded error" can be simulated with a POM file containing a single dependency

<dependency>

    <groupId>io.netty</groupId>
    <artifactId>netty-tcnative-boringssl-static</artifactId>
    <version>2.0.54.Final</version>

</dependency>

--- maven-dependency-plugin:2.8:tree (default-cli) @ bookstore-v3 ---
be.liantis:bookstore-v3:jar:0.0.1-SNAPSHOT
\- io.netty:netty-tcnative-boringssl-static:jar:2.0.54.Final:compile
    +- io.netty:netty-tcnative-classes:jar:2.0.54.Final:compile
    +- io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.54.Final:compile
    +- io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.54.Final:compile
    +- io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.54.Final:compile
    +- io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.54.Final:compile
    \- io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.54.Final:compile

Transitive dependencies, e.g. netty-tcnative-boringssl-static:jar:linux-x86_64, with a classifier (linux-x86_64) are registered as dependencies with a PackageURL equal to the packageURL of the parent netty-tcnative-boringssl-static. As a result, the recursive 'addTransitiveDeps" function never ends ==> Maximum call stack size exceeded

Can be avoided by checking for an unique dependency namespace or dependency name before adding the actual dependency.... Simple test updated to reflect this special case