### PR TITLE
fix: mavenArgs are unused

### DIFF
--- a/src/snapshot-generator.ts
+++ b/src/snapshot-generator.ts
@@ -63,7 +63,7 @@ function getDetector() {
 
 export async function generateDependencyGraph(directory: string, config?: MavenConfiguration): Promise<Depgraph> {
   try {
-    const mvn = new MavenRunner(directory, config?.settingsFile, config?.ignoreMavenWrapper);
+    const mvn = new MavenRunner(directory, config?.settingsFile, config?.ignoreMavenWrapper, config?.mavenArgs);
 
     core.startGroup('depgraph-maven-plugin:reactor');
     const mavenReactorArguments = [


### PR DESCRIPTION
Use `mavenArgs` from inputs when constructing MavenRunner so that specifying `maven-args` in a workflow YAML actually works.

For example
```yaml
      - name: Submit Dependency Snapshot
        uses: advanced-security/maven-dependency-submission-action@v3
        with:
          maven-args: -Dmaven.repo.local=/tmp/.m2/repository
```