### PR TITLE
Do not throw exceptions from fileExists()

### DIFF
--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -18,14 +18,7 @@ export function fileExists(file?: string): boolean {
     return false;
   }
 
-  try {
-    const wrapperFileStats = fs.statSync(file);
-    // TODO might need to deal with a linked file, but ingoring that for now
-    return wrapperFileStats && wrapperFileStats.isFile();
-  } catch (err: any) {
-    if (err.code == 'ENOENT') {
-      return false;
-    }
-    throw err;
-  }
+  const wrapperFileStats = fs.statSync(file, {throwIfNoEntry: false});
+  // TODO might need to deal with a linked file, but ingoring that for now
+  return wrapperFileStats && wrapperFileStats.isFile();
 }


### PR DESCRIPTION
This commit changes the function call to `fs.statSync()` by passing an additional option, `throwIfNoEntry`, as `false`. This has the effect of not throwing an exception and instead returning `undefined`.

This simplifies the logic and, more importantly, it treats the function as a simple boolean function without side-effects, as that is how it is used and should be used. Otherwise, one might see errors like...

```
2023-05-15T15:46:17.0706854Z ##[group]Run advanced-security/maven-dependency-submission-action@v3.0.1
2023-05-15T15:46:17.0707248Z with:
2023-05-15T15:46:17.0707566Z   directory: /home/runner/work/security-champions/security-champions
2023-05-15T15:46:17.0707907Z   ignore-maven-wrapper: false
2023-05-15T15:46:17.0708233Z   snapshot-include-file-name: true
2023-05-15T15:46:17.0708638Z   token: ***
2023-05-15T15:46:17.0710059Z ##[endgroup]
2023-05-15T15:46:17.2078452Z ##[group]depgraph-maven-plugin:reactor
2023-05-15T15:46:17.2156101Z ##[warning]Error encountered executing maven: Unable to locate executable file: /home/runner/work/security-champions/security-champions/mvnw. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
2023-05-15T15:46:17.2165615Z 
2023-05-15T15:46:17.2165623Z 
2023-05-15T15:46:17.2166055Z ##[endgroup]
2023-05-15T15:46:17.2167638Z ##[error]Error: Failed to successfully generate reactor results with Maven, exit code: -1
2023-05-15T15:46:17.2169713Z ##[error]Error: A problem was encountered generating dependency files, please check execution logs for details; Failed to successfully generate reactor results with Maven, exit code: -1
2023-05-15T15:46:17.2172090Z ##[error]Failed to generate a dependency snapshot, check logs for more details, Error: A problem was encountered generating dependency files, please check execution logs for details; Failed to successfully generate reactor results with Maven, exit code: -1
```