### PR TITLE
Update README example to use v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Generating and submitting a dependency snapshot using the defaults:
 
 ```
 - name: Submit Dependency Snapshot
-  uses: advanced-security/maven-dependency-submission-action@v3
+  uses: advanced-security/maven-dependency-submission-action@v4
 ```
 
 Upon success it will generate a snapshot captured from Maven POM like;


### PR DESCRIPTION
It looks like v4 has been around since January, so it's probably safe to market it as the primary tag to use.