### PR TITLE
Sync fork daily at midnight

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,15 @@
+name: Sync fork
+on:
+  schedule:
+    # Daily at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch: {}
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - run: gh repo sync actions/maven-dependency-submission-action -b main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Keep the fork in sync by running `gh repo sync` daily at midnight.