### PR TITLE
Stop assuming unix paths when locating pom.xml

### DIFF
--- a/src/depgraph.ts
+++ b/src/depgraph.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 import { PackageURL } from 'packageurl-js'
 import { PackageCache, Package, Manifest } from '@github/dependency-submission-toolkit';
 import { DependencyScope } from '@github/dependency-submission-toolkit';
@@ -175,7 +177,7 @@ export class MavenDependencyGraph {
 
 export function parseDependencyJson(file: string): Depgraph {
   const data = loadFileContents(file);
-  const pomXmlFilepath = file.replace(`target/${depgraphfilename}`, 'pom.xml');
+  const pomXmlFilepath = file.replace(path.join('target', depgraphfilename), 'pom.xml');
 
   if (!data) {
     return {

--- a/src/maven-runner.test.ts
+++ b/src/maven-runner.test.ts
@@ -13,7 +13,7 @@ describe('maven-runner', () => {
       const runner = new MavenRunner(projectDir);
 
       expect(runner.configuration.executable).toBeDefined();
-      expect(runner.configuration.executable).toBe('mvn');
+      expect(runner.configuration.executable).toBeOneOf(['mvn', 'mvn.cmd']);
       expect(runner.configuration.settingsFile).toBeUndefined();
     }, 20000);
 
@@ -23,7 +23,10 @@ describe('maven-runner', () => {
       const runner = new MavenRunner(projectDir);
 
       expect(runner.configuration.executable).toBeDefined();
-      expect(runner.configuration.executable).toBe(path.join(projectDir, 'mvnw'));
+      expect(runner.configuration.executable).toBeOneOf([
+        path.join(projectDir, 'mvnw'),
+        path.join(projectDir, 'mvnw.cmd')
+      ]);
       expect(runner.configuration.settingsFile).toBeUndefined();
     }, 20000);
 
@@ -36,7 +39,7 @@ describe('maven-runner', () => {
         const runner = new MavenRunner(projectDir, settings);
 
         expect(runner.configuration.executable).toBeDefined();
-        expect(runner.configuration.executable).toBe('mvn');
+        expect(runner.configuration.executable).toBeOneOf(['mvn', 'mvn.cmd']);
         expect(runner.configuration.settingsFile).toBe(settings);
       });
 


### PR DESCRIPTION
* Using `path.join` to build the Dependency Graph `.json` path when building the source location to the `pom.xml`. Fixes #124.
* Adding `.cmd` variants of `mvn` and `mvnw` in tests so they pass on Windows machines.