### PR TITLE
Automate tracked releases and floating version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,6 @@ jobs:
           commit-message: "chore: bump version (${{ inputs.bump }})"
           title: "chore: bump version (${{ inputs.bump }})"
           branch: chore/release-${{ inputs.bump }}
-          labels: version
           body: |
             Automated pull request to bump the tracked release version,
             update README.md, synchronize package-lock.json, and rebuild dist/.
@@ -101,6 +100,19 @@ jobs:
 
           if ! git cat-file -e "${BEFORE_SHA}:.release.yml" 2>/dev/null; then
             echo "::notice::Initialized release tracking at v$current_version without publishing a release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          previous_version=$(git show "${BEFORE_SHA}:.release.yml" |
+            sed -n -E 's/^version:[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p')
+          if [ -z "$previous_version" ]; then
+            echo "::error::Could not read the previous version from .release.yml"
+            exit 1
+          fi
+
+          if [ "$current_version" = "$previous_version" ]; then
+            echo "::notice::.release.yml changed without a version bump; no release will be published."
             echo "release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".release.yml"
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Open a version bump PR. Ignored if version is set."
+        type: choice
+        options:
+          - none
+          - patch
+          - minor
+          - major
+        default: none
+      version:
+        description: "Explicit version to release immediately (e.g., 6.0.0)."
+        type: string
+        default: ""
+      prerelease:
+        description: "Publish the explicit version as a pre-release"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.version == '' && inputs.bump != 'none' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Bump version
+        uses: docker://ghcr.io/42bytelabs/patch-release-me:0.6.7@sha256:b9624359ce08707dfb4d22bcbf9d1a75f7f4718ccec610ddaa62280ffea98958
+        with:
+          args: --disable-banner bump -m ${{ inputs.bump }}
+
+      - name: Sync package lock
+        run: npm install --package-lock-only --ignore-scripts
+
+      - name: Rebuild distribution
+        run: npm run build
+
+      - name: Create release pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ github.token }}
+          commit-message: "chore: bump version (${{ inputs.bump }})"
+          title: "chore: bump version (${{ inputs.bump }})"
+          branch: chore/release-${{ inputs.bump }}
+          labels: version
+          body: |
+            Automated pull request to bump the tracked release version,
+            update README.md, synchronize package-lock.json, and rebuild dist/.
+
+  manual-release:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
+    uses: advanced-security/reusable-workflows/.github/workflows/release.yml@cdb58ebdac3e974822957b34c90394db7dd44ccc # v0.3.5
+    permissions:
+      contents: write
+    with:
+      version: ${{ inputs.version }}
+      prerelease: ${{ inputs.prerelease }}
+
+  fetch-release:
+    if: ${{ github.event_name == 'push' && !github.event.repository.fork }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      release: ${{ steps.check.outputs.release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check tracked version
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          current_version=$(sed -n -E 's/^version:[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' .release.yml)
+          if [ -z "$current_version" ]; then
+            echo "::error::Could not read a version from .release.yml"
+            exit 1
+          fi
+
+          if ! git cat-file -e "${BEFORE_SHA}:.release.yml" 2>/dev/null; then
+            echo "::notice::Initialized release tracking at v$current_version without publishing a release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          released_version=""
+          if latest_tag=$(gh api "/repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/tmp/gh-api-error); then
+            released_version="${latest_tag#v}"
+          elif ! grep -q "HTTP 404" /tmp/gh-api-error; then
+            echo "::error::Failed to look up the latest release"
+            cat /tmp/gh-api-error
+            exit 1
+          fi
+
+          if [ "$current_version" = "$released_version" ]; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$current_version" >> "$GITHUB_OUTPUT"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    needs: fetch-release
+    if: ${{ needs.fetch-release.outputs.release == 'true' }}
+    uses: advanced-security/reusable-workflows/.github/workflows/release.yml@cdb58ebdac3e974822957b34c90394db7dd44ccc # v0.3.5
+    permissions:
+      contents: write
+    with:
+      version: ${{ needs.fetch-release.outputs.version }}

--- a/.release.yml
+++ b/.release.yml
@@ -1,0 +1,16 @@
+name: "maven-dependency-submission-action"
+repository: "advanced-security/maven-dependency-submission-action"
+version: "6.0.0"
+
+locations:
+  - name: "Node Manifest"
+    paths:
+      - package.json
+    patterns:
+      - '"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'
+
+  - name: "Documentation"
+    paths:
+      - README.md
+    patterns:
+      - 'advanced-security/maven-dependency-submission-action@v([0-9]+\.[0-9]+\.[0-9]+)'

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
         java-version: ${{ matrix.java-version }}
     - name: Submit Dependency Snapshot
       uses: advanced-security/maven-dependency-submission-action@v6.0.0
-       with:
+      with:
         directory: ${{ matrix.directory }}
         correlator: ${{ github.job }}-${{ matrix.directory }}
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Generating and submitting a dependency snapshot using the defaults:
 
 ```
 - name: Submit Dependency Snapshot
-  uses: advanced-security/maven-dependency-submission-action@v5
+  uses: advanced-security/maven-dependency-submission-action@v6.0.0
 ```
 
 Upon success it will generate a snapshot captured from Maven POM like;
@@ -67,7 +67,7 @@ jobs:
       with:
         java-version: ${{ matrix.java-version }}
     - name: Submit Dependency Snapshot
-      uses: advanced-security/maven-dependency-submission-action@v3
+      uses: advanced-security/maven-dependency-submission-action@v6.0.0
        with:
         directory: ${{ matrix.directory }}
         correlator: ${{ github.job }}-${{ matrix.directory }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maven-dependency-submission-action",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maven-dependency-submission-action",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-dependency-submission-action",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Submit Maven dependencies to GitHub dependency submission API",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

- add `.release.yml` as the source of truth for repository, package, and README versions
- add a reusable-workflow-backed release pipeline that opens version bump PRs, rebuilds `dist/`, and publishes releases after merge
- update package metadata and README examples to the existing immutable `v6.0.0` prerelease baseline
- create/update floating major and minor tags only when publishing stable releases

## Release plan

`v6.0.0` remains an immutable prerelease. Merging this PR initializes release tracking without attempting to republish it. After merge, dispatch **Release** with `bump: patch`; the workflow will open the `v6.0.1` stable-release PR and update all tracked version references.