### PR TITLE
Fix reusable release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
     uses: advanced-security/reusable-workflows/.github/workflows/release.yml@cdb58ebdac3e974822957b34c90394db7dd44ccc # v0.3.5
     permissions:
       contents: write
+      pull-requests: write
     with:
       version: ${{ inputs.version }}
       prerelease: ${{ inputs.prerelease }}
@@ -139,5 +140,6 @@ jobs:
     uses: advanced-security/reusable-workflows/.github/workflows/release.yml@cdb58ebdac3e974822957b34c90394db7dd44ccc # v0.3.5
     permissions:
       contents: write
+      pull-requests: write
     with:
       version: ${{ needs.fetch-release.outputs.version }}


### PR DESCRIPTION
## Summary

Grant `pull-requests: write` to both jobs that call the shared release workflow.

GitHub validates the permissions requested by every nested job before evaluating its condition. The shared workflow's optional `update-readme-sha` job declares `pull-requests: write`, so callers must grant it even when that input is disabled.

This fixes the startup failure introduced by #156. Merging this PR only repairs the workflow definition; it does not publish `v6.0.0`.